### PR TITLE
tmp: test libass build

### DIFF
--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -22,3 +22,5 @@ RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
 
 COPY build.sh *.options $SRC/
+
+RUN echo "Hi"

--- a/projects/libass/build.sh
+++ b/projects/libass/build.sh
@@ -44,3 +44,5 @@ cp fuzz/fuzz_ossfuzz $OUT/libass_fuzzer
 cp fuzz/ass.dict $OUT/ass.dict
 
 cp $SRC/*.options $OUT/
+
+echo "Hi."


### PR DESCRIPTION
locally fails during linking with
```
/usr/bin/ld: __sancov_cntrs has both ordered [`__sancov_cntrs[fribidi_get_par_direction]' in /work/lib/libfribidi.a(fribidi-bidi.o)] and unordered [`__sancov_cntrs[get_fallback]' in libass/.libs/ass_fontconfig.o] sections
/usr/bin/ld: final link failed: bad value
```