### PR TITLE
Libass tweaks

### DIFF
--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfontconfig1-dev libfreetype-dev libfribidi-dev python3-pip && \
-    pip3 install meson==0.55.0 ninja
+    pip3 install meson==0.60.0 ninja
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git

--- a/projects/libass/build.sh
+++ b/projects/libass/build.sh
@@ -38,7 +38,9 @@ cd $SRC/libass
 
 export PKG_CONFIG_PATH=/work/lib/pkgconfig
 ./autogen.sh
-./configure FUZZ_CPPFLAGS="-DASS_FUZZMODE=2" --disable-asm --disable-shared --enable-fuzz
+./configure \
+  FUZZ_CPPFLAGS="-DASS_FUZZMODE=2 -DASSFUZZ_MAX_LEN=8192" \
+  --disable-asm --disable-shared --enable-fuzz
 make -j "$(nproc)" fuzz/fuzz_ossfuzz
 cp fuzz/fuzz_ossfuzz $OUT/libass_fuzzer
 cp fuzz/ass.dict $OUT/ass.dict

--- a/projects/libass/libass_fuzzer.options
+++ b/projects/libass/libass_fuzzer.options
@@ -1,2 +1,3 @@
 [libfuzzer]
 dict = ass.dict
+max_len = 8192


### PR DESCRIPTION
- need to ask OSS-Fuzz maintainers to prune excessively large sample files from corpus
- while all fuzzing engines themselves expose flags to limit max case len, there appears to be no way to set it except for libfuzzer (see second commit message)
- we still don't know why coverage is supposedly so low, when locally it’s much higher and parsing coverage shouldn't be affected by missing fonts
- i’m not sure how to best go about the fontprovider issue. To get a fontconfig file in a relative path is fine, but we need a way to set an env var (could be included in the fuzzer binary if necessary), but the font file needs to be at a fixed location we can reference from the fontconfig config file (does not appear reasonable to add to the fuzzer binary)
Alternatively, forego system font provider and during build include a simple memory font *(a bit annoying to integrate though and means less testing for system font provider paths)*

There’s also a new default fuzzing engine “centipede”. Trying to build with it locally failed, but it succeeds in GHA and can be enabled by just [omitting the explicit fuzzing engine list](https://github.com/TheOneric/oss-fuzz/commit/2369b74c17588cfcd51b2d557e6d4909747931a5), but mpv [explicitly disabled](https://github.com/TheOneric/oss-fuzz/pull/3/commits/2369b74c17588cfcd51b2d557e6d4909747931a5) centipede before due to flakiness, so not sure we actually want to do that.